### PR TITLE
Remove the CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gme.kasoki.de


### PR DESCRIPTION
This will allow the site to be accessible at http://atomicptr.github.io/GameMechanicExplorer-HaxeFlixel since the http://gme.kasoki.de domain is no longer serving this site.

This website is linked to from http://haxeflixel.com/documentation/faq/, so I thought it would be good to get it serving again. I'll submit a PR to the HaxeFlixel docs with the updated URL.